### PR TITLE
feat: Implement non-blocking UI for LLM calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The application is structured for clarity, with the user interface managed by `a
 
 3. **Install dependencies**
 
-   The `requirements.txt` file lists all necessary Python packages, including Streamlit, LangChain components, and Requests.
+   The `requirements.txt` file lists all necessary Python packages, including Streamlit, LangChain components, Requests, `streamlit-autorefresh`, and other utilities.
    ```sh
    pip install -r requirements.txt
    ```
@@ -91,6 +91,14 @@ Once the app is running, interact with the AI Assistant via the web interface:
     - It uses a token-based sliding window approach, prioritizing recent parts of the conversation if the total length becomes too extensive (currently around 3000 tokens using `cl100k_base` tokenizer).
     - This helps ensure stable performance and prevents errors during long interactions.
     - The AI's system prompt also includes a gentle reminder that it may not recall the earliest parts of a very long discussion.
+- **Asynchronous LLM Calls (Non-Blocking UI)**:
+    - The application now processes LLM requests in the background, ensuring the user interface remains responsive.
+    - **User Experience**:
+        - When you send a message, a "🧠 Thinking..." placeholder will appear immediately in the chat.
+        - The chat input field will be temporarily disabled until the AI's response is received.
+        - The application UI should not freeze during LLM processing.
+        - The app uses `streamlit-autorefresh` to periodically check for results in the background, which may cause slight, brief screen refreshes while waiting for the AI's response.
+    - This is achieved using a background task manager (`LLMTaskManager`) and the `streamlit-autorefresh` component for periodic updates.
 
 ### Example Queries:
 

--- a/app.py
+++ b/app.py
@@ -7,11 +7,20 @@ It uses `llm_logic.py` for the core language model interactions.
 """
 import streamlit as st
 from streamlit_local_storage import LocalStorage # Import LocalStorage
+from streamlit_autorefresh import st_autorefresh # Import autorefresh
 from llm_logic import (
     init_llm_engine,
     build_prompt_chain,
     generate_ai_response
 )
+from task_manager import LLMTaskManager # Import TaskManager
+import logging # Import logging
+
+# Initialize Task Manager
+task_manager = LLMTaskManager()
+
+# Autorefresh every 2 seconds
+st_autorefresh(interval=2000, limit=None, key="llm_refresh")
 
 # Function to load CSS
 def load_css(file_name):
@@ -91,13 +100,14 @@ selected_model, temperature, top_k, top_p, clear_history_pressed = display_sideb
 if clear_history_pressed:
     st.session_state.message_log = [{"role": "ai", "content": "Hi! I'm DeepSeek. How can I help you code today? 💻"}]
     localS.deleteItem('message_log')
+    # Clear active task if any, as history is gone
+    st.session_state.active_llm_task = None 
     st.rerun()
 
 # Initialize the LLM engine with selected settings
 llm_engine = init_llm_engine(selected_model, temperature, top_k, top_p)
 
-# Session State Management for chat history
-# Initialize message_log in session_state if it doesn't exist
+# Session State Management for chat history and active task
 if "message_log" not in st.session_state:
     # Try to load chat history from local storage
     stored_message_log = localS.getItem('message_log')
@@ -107,31 +117,79 @@ if "message_log" not in st.session_state:
         # Default welcome message if no history is found
         st.session_state.message_log = [{"role": "ai", "content": "Hi! I'm DeepSeek. How can I help you code today? 💻"}]
 
+if "active_llm_task" not in st.session_state:
+    st.session_state.active_llm_task = None
+
+# Result Checking and UI Update (on each rerun, including autorefresh)
+if st.session_state.active_llm_task:
+    task_id = st.session_state.active_llm_task["id"]
+    placeholder_idx = st.session_state.active_llm_task["placeholder_idx"]
+    status = task_manager.get_task_status(task_id)
+
+    if status == "completed":
+        ai_response = task_manager.get_task_result(task_id)
+        st.session_state.message_log[placeholder_idx]["content"] = ai_response
+        task_manager.cleanup_task_result(task_id)
+        st.session_state.active_llm_task = None
+        localS.setItem('message_log', st.session_state.message_log) # Save final history
+        st.rerun()
+    elif status == "error":
+        error_details_val = "Unknown error" # Default error message
+        try:
+            # This re-raises the exception, so we catch it to get details
+            task_manager.get_task_result(task_id) 
+        except Exception as e:
+            error_details_val = str(e)
+        st.session_state.message_log[placeholder_idx]["content"] = f"⚠️ Error: {error_details_val}"
+        task_manager.cleanup_task_result(task_id)
+        st.session_state.active_llm_task = None
+        localS.setItem('message_log', st.session_state.message_log) # Save history with error
+        st.rerun()
+    elif status == "not_found" and task_id in st.session_state.get('_llm_tasks_results', {}):
+        # This case implies status was checked after result was processed and future removed
+        # but before active_llm_task was cleared. Or a general logic error.
+        # For safety, clear active_llm_task if result is present
+        logging.warning(f"Task {task_id} was not found in futures but result exists. Clearing active task.")
+        # Attempt to finalize the message if possible, or mark as unknown error
+        if task_id in st.session_state._llm_tasks_results:
+            result = st.session_state._llm_tasks_results[task_id]
+            if isinstance(result, Exception):
+                 st.session_state.message_log[placeholder_idx]["content"] = f"⚠️ Error: {str(result)}"
+            else:
+                 st.session_state.message_log[placeholder_idx]["content"] = result
+            localS.setItem('message_log', st.session_state.message_log) # Save history
+        task_manager.cleanup_task_result(task_id) # ensure cleanup
+        st.session_state.active_llm_task = None
+        st.rerun()
+
 # Display the existing chat messages
 display_chat_interface(st.session_state.message_log)
 
 # User Input Handling
-# Get user input from the chat_input widget
-user_query = st.chat_input("Type your coding question here...")
+chat_input_disabled = st.session_state.active_llm_task is not None
+user_query = st.chat_input("Type your coding question here...", disabled=chat_input_disabled, key="user_query_input")
 
-# Process user input if it's valid (not empty or just whitespace)
-if user_query and user_query.strip():
+if user_query and user_query.strip() and not chat_input_disabled:
     # Add user's query to the message log
     st.session_state.message_log.append({"role": "user", "content": user_query})
     
-    # Show a spinner while processing the query
-    with st.spinner("🧠 Processing..."):
-        # Build the prompt chain based on the current message log
-        prompt_chain = build_prompt_chain(st.session_state.message_log)
-        # Generate AI response using the LLM engine and prompt chain
-        ai_response = generate_ai_response(llm_engine, prompt_chain)
-
-    # Add AI's response to the message log
-    st.session_state.message_log.append({"role": "ai", "content": ai_response})
-    # Save updated message log to local storage
-    localS.setItem('message_log', st.session_state.message_log)
-    # Rerun the Streamlit app to update the chat interface
+    # Add a placeholder AI message
+    ai_placeholder = {"role": "ai", "content": "🧠 Thinking..."}
+    st.session_state.message_log.append(ai_placeholder)
+    placeholder_idx = len(st.session_state.message_log) - 1
+    
+    # Submit to Task Manager
+    # Exclude the placeholder from the prompt chain
+    prompt_chain = build_prompt_chain(st.session_state.message_log[:-1]) 
+    task_id = task_manager.submit_task(generate_ai_response, llm_engine, prompt_chain)
+    
+    # Store task info
+    st.session_state.active_llm_task = {"id": task_id, "placeholder_idx": placeholder_idx}
+    
+    # Clear the actual chat input field by resetting its key
+    st.session_state.user_query_input = "" 
+    
+    # Rerun to immediately show the user message and placeholder, and disable input
     st.rerun()
-elif user_query:  # If user_query exists but is only whitespace
-    # Display a toast message for invalid input
+elif user_query and not user_query.strip(): # If user_query exists but is only whitespace
     st.toast("⚠️ Input cannot be empty or whitespace.", icon="🚫")

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ requests==2.32.3
 pytest==8.0.0
 streamlit-local-storage==0.0.25
 tiktoken==0.7.0
+streamlit-autorefresh==0.1.0

--- a/task_manager.py
+++ b/task_manager.py
@@ -1,0 +1,83 @@
+import streamlit as st
+import concurrent.futures
+import uuid
+import logging # Optional: for logging task statuses
+
+@st.experimental_singleton # Ensure only one instance of the manager exists
+class LLMTaskManager:
+    def __init__(self):
+        # Using ThreadPoolExecutor for I/O bound LLM calls
+        self._executor = concurrent.futures.ThreadPoolExecutor(max_workers=5) # max_workers can be tuned
+        # Using st.session_state to store task futures and results, keyed by task_id
+        # This makes them inherently session-specific.
+        if '_llm_tasks_futures' not in st.session_state:
+            st.session_state._llm_tasks_futures = {}
+        if '_llm_tasks_results' not in st.session_state:
+            st.session_state._llm_tasks_results = {}
+
+    def submit_task(self, func, *args, **kwargs):
+        """
+        Submits a function to the executor and returns a unique task ID.
+        Stores the future in st.session_state._llm_tasks_futures.
+        """
+        task_id = str(uuid.uuid4())
+        future = self._executor.submit(func, *args, **kwargs)
+        st.session_state._llm_tasks_futures[task_id] = future
+        logging.info(f"Task {task_id} submitted for function {func.__name__}")
+        return task_id
+
+    def get_task_status(self, task_id):
+        """
+        Returns the status of the task ("running", "completed", "error", or "not_found").
+        If completed or error, stores result/exception in st.session_state._llm_tasks_results
+        and removes future from st.session_state._llm_tasks_futures.
+        """
+        if task_id not in st.session_state._llm_tasks_futures:
+            # Check if it was completed and future removed, but result is available
+            if task_id in st.session_state._llm_tasks_results:
+                 # If result is an Exception, it's an error status
+                return "error" if isinstance(st.session_state._llm_tasks_results[task_id], Exception) else "completed"
+            return "not_found"
+
+        future = st.session_state._llm_tasks_futures[task_id]
+
+        if future.running():
+            return "running"
+        elif future.done():
+            try:
+                result = future.result()
+                st.session_state._llm_tasks_results[task_id] = result
+                logging.info(f"Task {task_id} completed. Result stored.")
+                del st.session_state._llm_tasks_futures[task_id] # Clean up future
+                return "completed"
+            except Exception as e:
+                st.session_state._llm_tasks_results[task_id] = e # Store exception as result
+                logging.error(f"Task {task_id} resulted in error: {e}")
+                del st.session_state._llm_tasks_futures[task_id] # Clean up future
+                return "error"
+        return "unknown" # Should ideally not happen
+
+    def get_task_result(self, task_id):
+        """
+        Returns the result of a completed task from st.session_state._llm_tasks_results.
+        Returns None if task is not found or result not yet available (should check status first).
+        Raises the exception if the task resulted in an error.
+        """
+        result = st.session_state._llm_tasks_results.get(task_id)
+        if isinstance(result, Exception):
+            raise result # Re-raise the exception so caller can handle
+        return result
+
+    def cleanup_task_result(self, task_id):
+        """
+        Removes a task's result from session state. Useful after result is processed.
+        """
+        if task_id in st.session_state._llm_tasks_results:
+            del st.session_state._llm_tasks_results[task_id]
+            logging.info(f"Cleaned up result for task {task_id}")
+
+
+# To ensure the singleton is initialized when the module is imported.
+# This allows app.py to just import and use it.
+# get_llm_task_manager = LLMTaskManager() # This is not how singletons are typically "pre-initialized" for use.
+# Instead, the app will call LLMTaskManager() and st.experimental_singleton handles it.


### PR DESCRIPTION
This commit introduces a non-blocking user interface for LLM interactions, improving app responsiveness during text generation.

Key changes:
- Added `streamlit-autorefresh` for periodic UI updates.
- Created `task_manager.py` with `LLMTaskManager`:
    - Uses `st.experimental_singleton` for a shared manager instance.
    - Employs `concurrent.futures.ThreadPoolExecutor` to run LLM calls in background threads.
    - Task futures and results are stored in `st.session_state` for session-specificity.
- Modified `app.py`:
    - LLM tasks are submitted to `LLMTaskManager` without blocking.
    - An immediate "Thinking..." placeholder is shown in the chat.
    - Your chat input is disabled while a response is being generated.
    - `streamlit-autorefresh` triggers periodic checks for task completion.
    - The UI updates with the AI's response or an error message once available.
- `llm_logic.py` was confirmed suitable for threaded execution.
- Updated `README.md` to document the new non-blocking behavior, the role of `streamlit-autorefresh`, and your experience.