### PR TITLE
feat: Implement Predefined Prompts/Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ The application is structured for clarity, with the user interface managed by `a
 Once the app is running, interact with the AI Assistant via the web interface:
 
 - **Chat Interface**: Type your coding-related questions into the input box at the bottom of the screen.
+- **Predefined Actions**: Select a specific task from the "Choose Action" dropdown in the sidebar to tailor the AI's focus and system prompt. Available actions include:
+    - **General Chat**: For general coding questions, discussions, and assistance (default).
+    - **Explain Code**: Provide a code snippet and ask the AI to explain its functionality, logic, and purpose.
+    - **Debug Code**: Submit code along with error messages or a description of the issue to get help identifying bugs and potential fixes.
+    - **Write Documentation**: Ask the AI to generate technical documentation (e.g., function summaries, parameter descriptions) for a given piece of code.
 - **Model Selection**: Choose between different DeepSeek models from the sidebar.
 - **Temperature Control**: Adjust the "Select Temperature" slider in the sidebar (range 0.0 to 1.0, default 0.3).
     - Lower values (e.g., 0.1-0.3) produce more focused and deterministic responses.


### PR DESCRIPTION
This commit introduces a feature allowing you to select predefined actions to tailor my behavior for specific tasks.

Key changes:
- Defined four actions: "General Chat", "Explain Code", "Debug Code", and "Write Documentation".
- Created specific system prompt texts for each action in `llm_logic.py`.
- Added a `get_system_prompt(action)` function in `llm_logic.py` to retrieve the appropriate prompt.
- `build_prompt_chain` in `llm_logic.py` now dynamically uses the system prompt corresponding to the `selected_action`.
- Added a `st.selectbox` in the sidebar of `app.py` for you to choose an action.
- The `selected_action` is passed from `app.py` to `llm_logic.py`.
- Updated `README.md` to document this new feature and list the available actions.