### PR TITLE
feat: Add loading indicator for model switching and cache LLM engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ Once the app is running, interact with the AI Assistant via the web interface:
     - It uses a token-based sliding window approach, prioritizing recent parts of the conversation if the total length becomes too extensive (currently around 3000 tokens using `cl100k_base` tokenizer).
     - This helps ensure stable performance and prevents errors during long interactions.
     - The AI's system prompt also includes a gentle reminder that it may not recall the earliest parts of a very long discussion.
+- **Model Loading Indicator & Caching**:
+    - When you change the selected AI model or adjust its core parameters (like Temperature, Top K, Top P), a loading indicator (spinner) will appear while the new model configuration is being initialized. This provides clear feedback during model setup.
+    - The AI model engine is cached within your current session. The loading indicator will only appear if the model or its key parameters need to be re-initialized, saving time on subsequent operations if the configuration hasn't changed.
 - **Asynchronous LLM Calls (Non-Blocking UI)**:
     - The application now processes LLM requests in the background, ensuring the user interface remains responsive.
     - **User Experience**:


### PR DESCRIPTION
This commit introduces a loading indicator when the AI model or its parameters are changed, and implements caching for the LLM engine to prevent unnecessary re-initializations.

Key changes:
- Initialized session state variables in `app.py` to store the current LLM engine instance and its configuration parameters (`current_llm_model_name`, `current_temperature`, `current_top_k`, `current_top_p`).
- Implemented logic in `app.py` to compare selected LLM parameters from the sidebar with the stored parameters in `st.session_state`.
- If a change is detected or the engine is not yet initialized, `init_llm_engine` is called within an `st.spinner` context, providing visual feedback to you.
- The newly initialized engine and its parameters are then cached in `st.session_state`.
- If no relevant parameters have changed on a script rerun, the cached LLM engine from `st.session_state` is used, improving performance.
- Updated `README.md` to document this new loading indicator and caching feature.