### PR TITLE
feat: Implement toggle for custom dark theme

### DIFF
--- a/Explanation.md
+++ b/Explanation.md
@@ -41,6 +41,15 @@ st.markdown("""
   - **Gray theme** for the sidebar (`#2d2d2d`).
   - **White text on dark backgrounds** for input fields and select boxes.
 
+### Theme Customization
+
+The application utilizes a custom dark theme by default to provide a consistent look and feel. This theme is defined in the `styles.css` file.
+
+Users have the option to toggle this custom dark theme on or off:
+- In the sidebar, there is an "Enable Custom Dark Theme" switch.
+- **Enabled (Default)**: The custom dark theme styles are applied.
+- **Disabled**: The custom dark theme styles are not loaded. The application will then revert to Streamlit's native theming, which respects your operating system (OS) or browser's light/dark mode settings. This allows you to use Streamlit's default light theme if your system is set to light mode, or Streamlit's default dark theme if your system is set to dark mode.
+
 ## **3. App Title and Description**
 ```python
 st.title("🧠 DeepSeek Code Companion")

--- a/app.py
+++ b/app.py
@@ -36,6 +36,8 @@ if "current_top_k" not in st.session_state:
     st.session_state.current_top_k = None
 if "current_top_p" not in st.session_state:
     st.session_state.current_top_p = None
+if "use_custom_dark_theme" not in st.session_state:
+    st.session_state.use_custom_dark_theme = True # Default to True
 
 # Function to load CSS
 def load_css(file_name):
@@ -47,8 +49,9 @@ def load_css(file_name):
     with open(file_name) as f:
         st.markdown(f'<style>{f.read()}</style>', unsafe_allow_html=True)
 
-# Load custom CSS from styles.css
-load_css("styles.css")
+# Conditionally load custom CSS based on session state
+if st.session_state.get("use_custom_dark_theme", True):
+    load_css("styles.css")
 
 # UI Components
 def display_header():
@@ -75,6 +78,16 @@ def display_sidebar():
             help="Select a specific task for the AI to focus on. This will tailor its responses and system prompt."
         )
         st.divider() # Visual separation
+        
+        # Theme toggle
+        st.toggle(
+            "Enable Custom Dark Theme",
+            value=st.session_state.get("use_custom_dark_theme", True),
+            key="use_custom_dark_theme",
+            help="Toggle the custom dark theme for the application. When off, Streamlit's default theme will be used."
+        )
+        st.divider()
+
         # Model selection dropdown
         selected_model = st.selectbox("Choose Model", ["deepseek-r1:1.5b", "deepseek-r1:3b"], index=0)
         # Temperature slider for controlling LLM randomness


### PR DESCRIPTION
This commit introduces a feature allowing you to enable or disable the application's custom dark theme.

Key changes:
- Added `st.session_state.use_custom_dark_theme` (defaulting to `True`) to manage the theme preference within your session.
- Included an "Enable Custom Dark Theme" `st.toggle` switch in the sidebar of `app.py`, directly linked to the session state variable.
- Modified `app.py` to conditionally load `styles.css`. The custom dark theme is applied only if `st.session_state.use_custom_dark_theme` is `True`. If `False`, the application reverts to Streamlit's native theming, which respects your OS/browser settings for light or dark mode.
- Updated `Explanation.md` to document this new theme customization feature and the toggle functionality.