### PR TITLE
feat: Dockerize application for deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,40 @@
+# Git
+.git
+.gitignore
+
+# Python virtual environment
+venv/
+*.venv/
+.venv/
+
+# Python bytecode and cache
+__pycache__/
+*.py[cod]
+*$py.class
+
+# OS-specific files
+.DS_Store
+Thumbs.db
+
+# IDE and project files (examples, add more if needed for specific IDEs)
+.idea/
+.vscode/
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+
+# Secrets or local configuration (if any, though ideally not in repo)
+# .env
+
+# Test reports or build artifacts (if any)
+# htmlcov/
+# .tox/
+# .nox/
+# .coverage
+# .cache
+# nosetests.xml
+# coverage.xml
+# *.cover
+# *.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# 1. Base Image
+FROM python:3.10-slim
+
+# 2. Set Environment Variables
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+ENV PIP_NO_CACHE_DIR off
+ENV PIP_DISABLE_PIP_VERSION_CHECK on
+ENV PIP_DEFAULT_TIMEOUT 100
+
+# 3. Set Working Directory
+WORKDIR /app
+
+# 4. Install System Dependencies (if any needed later, e.g., for specific Python packages)
+# RUN apt-get update && apt-get install -y --no-install-recommends some-package && rm -rf /var/lib/apt/lists/*
+
+# 5. Copy requirements.txt and Install Python Dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# 6. Copy Application Code
+COPY . .
+
+# 7. Expose Port for Streamlit
+EXPOSE 8501
+
+# 8. Set Default Command to Run Streamlit App
+CMD ["streamlit", "run", "app.py", "--server.port=8501", "--server.address=0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -65,6 +65,84 @@ The application is structured for clarity, with the user interface managed by `a
 
    Open the link provided in the terminal (usually `http://localhost:8501`) in your web browser. Type in your coding-related queries to receive AI-powered assistance.
 
+## Deployment with Docker
+
+Deploying the DeepSeek Code Companion using Docker and Docker Compose offers a consistent and isolated environment, managing both the Streamlit application and the Ollama LLM service.
+
+### Prerequisites
+
+- **Docker**: Ensure Docker is installed on your system.
+  - Installation guide: [https://docs.docker.com/engine/install/](https://docs.docker.com/engine/install/)
+- **Docker Compose**: Ensure Docker Compose is installed.
+  - Installation guide: [https://docs.docker.com/compose/install/](https://docs.docker.com/compose/install/)
+
+### Running the Application
+
+1.  **Clone the repository** (if you haven't already):
+    ```bash
+    git clone https://github.com/chintanboghara/DeepSeek-CodeCompanion.git
+    cd DeepSeek-CodeCompanion
+    ```
+
+2.  **Start the application using Docker Compose**:
+    ```bash
+    docker-compose up --build
+    ```
+    - The `--build` flag is recommended for the first time you run the command or when there are changes to the `Dockerfile` or application code (e.g., `app.py`, `requirements.txt`). For subsequent runs, `docker-compose up` might be faster if no code changes occurred.
+    - This command will build the Docker image for the Streamlit application and start both the `app` and `ollama` services.
+
+3.  **Access the application**:
+    - Once the services are running, the Streamlit application will be available at `http://localhost:8501` in your web browser.
+
+### Ollama Model Management
+
+Ollama models are persisted in a Docker volume named `ollama_data` (as defined in `docker-compose.yml`). This means models you pull will be available even if you stop and restart the containers.
+
+To manage models within the Ollama service:
+
+-   **List currently available models**:
+    ```bash
+    docker-compose exec ollama ollama list
+    ```
+-   **Pull a new model** (e.g., `deepseek-r1:1.5b`):
+    ```bash
+    docker-compose exec ollama ollama pull deepseek-r1:1.5b
+    ```
+-   **Pull another model** (e.g., `deepseek-r1:3b`):
+    ```bash
+    docker-compose exec ollama ollama pull deepseek-r1:3b
+    ```
+    You only need to pull each model once. The application's sidebar will allow you to select from the models available to the Ollama service.
+
+### Ollama Base URL Configuration
+
+- The `docker-compose.yml` file automatically configures the `OLLAMA_BASE_URL` environment variable for the Streamlit application service (`app`) to `http://ollama:11434`. This is the internal address of the `ollama` service within the Docker network.
+- If you were running `app.py` locally for development (outside of this Docker Compose setup) and Ollama was also running locally, `app.py` would default to `http://localhost:11434` for the Ollama API, or you could set the `OLLAMA_BASE_URL` environment variable manually.
+
+### Stopping the Application
+
+To stop the application and remove the containers:
+```bash
+docker-compose down
+```
+- This command will stop and remove the containers defined in `docker-compose.yml`. The `ollama_data` volume will persist, preserving your downloaded Ollama models.
+
+### GPU Support (Note)
+
+The provided `docker-compose.yml` is configured for CPU usage by Ollama. For GPU support, you would need to uncomment and configure the `deploy` section within the `ollama` service definition in `docker-compose.yml`. This typically involves:
+- Ensuring your host system has the necessary NVIDIA drivers and the NVIDIA Container Toolkit installed.
+- Modifying the `deploy` section to specify GPU resources, for example:
+  ```yaml
+  # deploy:
+  #   resources:
+  #     reservations:
+  #       devices:
+  #         - driver: nvidia
+  #           count: 1 # or 'all'
+  #           capabilities: [gpu]
+  ```
+Refer to the official Docker and Ollama documentation for detailed instructions on GPU passthrough.
+
 ## Features and Usage
 
 Once the app is running, interact with the AI Assistant via the web interface:

--- a/app.py
+++ b/app.py
@@ -15,9 +15,13 @@ from llm_logic import (
 )
 from task_manager import LLMTaskManager # Import TaskManager
 import logging # Import logging
+import os # Import os
 
 # Initialize Task Manager
 task_manager = LLMTaskManager()
+
+# Get Ollama Base URL from environment variable or use default
+OLLAMA_BASE_URL = os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434")
 
 # Autorefresh every 2 seconds
 st_autorefresh(interval=2000, limit=None, key="llm_refresh")
@@ -152,7 +156,7 @@ needs_reinitialization = (
 
 if needs_reinitialization:
     with st.spinner(f"Initializing AI model: {selected_model}... Please wait."):
-        llm_engine = init_llm_engine(selected_model, temperature, top_k, top_p)
+        llm_engine = init_llm_engine(selected_model, temperature, top_k, top_p, OLLAMA_BASE_URL)
         st.session_state.llm_engine_instance = llm_engine
         st.session_state.current_llm_model_name = selected_model
         st.session_state.current_temperature = temperature

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,42 @@
+version: '3.8'
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8501:8501"
+    environment:
+      - OLLAMA_BASE_URL=http://ollama:11434
+      # Add any other environment variables your Streamlit app might need
+      # For example, if you had specific logging levels or feature flags:
+      # - LOG_LEVEL=INFO
+    depends_on:
+      - ollama
+    networks:
+      - deepseek_net
+
+  ollama:
+    image: ollama/ollama:latest # Use the latest official image
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama_data:/root/.ollama
+    # To enable GPU access (example for NVIDIA GPUs, uncomment and adapt if needed):
+    # deploy:
+    #   resources:
+    #     reservations:
+    #       devices:
+    #         - driver: nvidia
+    #           count: 1 # or 'all'
+    #           capabilities: [gpu]
+    networks:
+      - deepseek_net
+
+volumes:
+  ollama_data: # This volume persists Ollama models
+
+networks:
+  deepseek_net:
+    driver: bridge

--- a/llm_logic.py
+++ b/llm_logic.py
@@ -42,7 +42,7 @@ def get_system_prompt(action: str) -> str:
     return PREDEFINED_SYSTEM_PROMPTS.get(action, PREDEFINED_SYSTEM_PROMPTS["General Chat"])
 
 # Initialize Chat Engine
-def init_llm_engine(selected_model, temperature, top_k, top_p):
+def init_llm_engine(selected_model, temperature, top_k, top_p, ollama_base_url: str):
     """
     Initializes and returns the ChatOllama LLM engine.
 
@@ -52,6 +52,7 @@ def init_llm_engine(selected_model, temperature, top_k, top_p):
         top_k (int): Limits the set of next tokens to the K most probable.
         top_p (float): Controls diversity via nucleus sampling. Selects tokens
                        with cumulative probability greater than P.
+        ollama_base_url (str): The base URL for the Ollama API.
 
     Returns:
         ChatOllama: An instance of the ChatOllama engine.
@@ -59,7 +60,7 @@ def init_llm_engine(selected_model, temperature, top_k, top_p):
     model_kwargs = {'top_k': top_k, 'top_p': top_p}
     return ChatOllama(
         model=selected_model,
-        base_url="http://localhost:11434",
+        base_url=ollama_base_url,
         temperature=temperature,
         model_kwargs=model_kwargs
     )


### PR DESCRIPTION
This commit introduces Docker support for the DeepSeek Code Companion, allowing for easier deployment and a consistent running environment.

Key changes:
- Added a `.dockerignore` file to exclude unnecessary files from the Docker build context.
- Made the Ollama base URL configurable via the `OLLAMA_BASE_URL` environment variable in `app.py` and `llm_logic.py`. Defaults to `http://localhost:11434` if not set.
- Created a `Dockerfile` that:
    - Uses `python:3.10-slim` as the base image.
    - Installs dependencies from `requirements.txt`.
    - Copies application code.
    - Exposes port 8501 and runs the Streamlit app.
- Created a `docker-compose.yml` file that defines two services:
    - `app`: Builds the Streamlit application from the Dockerfile and sets `OLLAMA_BASE_URL` to connect to the `ollama` service.
    - `ollama`: Uses the official `ollama/ollama:latest` image and persists models in a named volume (`ollama_data`).
    - Services are connected via a custom bridge network.
- Updated `README.md` with a comprehensive "Deployment with Docker" section, including instructions for setup, running the application, managing Ollama models, and GPU considerations.