### PR TITLE
feat: Add copy-to-clipboard button for code blocks

### DIFF
--- a/app.py
+++ b/app.py
@@ -124,7 +124,35 @@ def display_chat_interface(message_log):
     with chat_container:
         for message in message_log:
             with st.chat_message(message["role"]): # Display message with role (user/ai)
-                st.markdown(message["content"])
+                if message["role"] == "ai":
+                    content = message["content"]
+                    parts = content.split("```")
+                    for i, part in enumerate(parts):
+                        if i % 2 == 1:  # This part is inside ``` ... ```
+                            lines = part.split('\n', 1)
+                            language = None
+                            code_content = part # Default to the whole part if no language line
+                            if lines: # Check if there's at least one line
+                                potential_lang = lines[0].strip().lower()
+                                # List of common languages, extend as needed
+                                known_languages = ["python", "javascript", "java", "c", "cpp", "sql", "html", "css", "shell", "bash", "json", "yaml", "markdown", ""] # Added "" for ``` block without lang
+                                if potential_lang in known_languages:
+                                    language = potential_lang if potential_lang else None # Use None if lang is ""
+                                    if len(lines) > 1:
+                                        code_content = lines[1]
+                                    else:
+                                        code_content = "" # No code content after language specifier
+                                else:
+                                    # No language specified or not recognized, treat whole block as code
+                                    language = None
+                                    code_content = part
+
+                            if code_content.strip(): # Only display if there's actual code
+                                st.code(code_content, language=language)
+                        elif part.strip():  # This part is outside ``` ... ``` and not empty
+                            st.markdown(part)
+                else:  # For user messages or other roles
+                    st.markdown(message["content"])
 
 # --- App Execution Flow ---
 


### PR DESCRIPTION
This enhancement modifies the chat interface to improve usability when interacting with AI-generated code snippets.

Previously, you had to manually select and copy code from my responses. This change introduces a "Copy Code" button for each code block.

The `app.py` file was updated in the `display_chat_interface` function:
- AI messages containing Markdown code blocks (e.g., ```python ... ```) are now parsed.
- Non-code parts of the message are rendered using `st.markdown`.
- Code blocks are rendered using `st.code`, which automatically provides a copy-to-clipboard button and attempts to apply syntax highlighting based on the language identifier.

This feature leverages Streamlit's built-in `st.code` component, ensuring a consistent user experience.