### PR TITLE
feat: Implement chat session management

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,12 +169,12 @@ Once the app is running, interact with the AI Assistant via the web interface:
     - This parameter limits the LLM's selection of the next token to the K most probable tokens, influencing response diversity.
 - **Top P (Nucleus) Sampling**: Adjust the "Top P" slider in the sidebar (default 0.9, range 0.0-1.0).
     - This parameter selects tokens based on their cumulative probability, ensuring that only the most probable tokens whose sum exceeds P are considered. It provides another way to control response diversity.
-- **Chat History Persistence**:
-    - Your conversations are automatically saved to your browser's local storage.
-    - This means you can close the browser or refresh the page, and your current chat history will be reloaded when you return.
-- **Clear Chat History**:
-    - A "Clear Chat History" button is available in the sidebar.
-    - Clicking this button will remove the current conversation from both the application's session and your browser's local storage, allowing you to start a fresh chat.
+- **Session Management**:
+    - **Saving Sessions**: You can save your current chat conversation for later use. In the sidebar under "💾 Chat Sessions", enter a unique name for your session in the text field and click "Save Current Session". This will store the current chat messages under that name in your browser's local storage. You can overwrite an existing session by saving with the same name.
+    - **Loading Sessions**: To resume a previous conversation, select its name from the "Load Session:" dropdown in the sidebar. The chat history will be loaded, and the session name will be displayed.
+    - **Deleting Sessions**: To remove a saved session, select its name from the "Delete Session:" dropdown and click "Delete Selected Session". This will permanently remove it from your browser's local storage.
+    - **Starting a New Session**: Click the "Clear Chat History" button in the sidebar. This will clear the current chat display and start a fresh, unnamed session. It does not delete any of your saved sessions.
+    - All session data is stored locally in your web browser.
 - **Improved Code Formatting**:
     - The AI has been instructed to consistently use Markdown code blocks with language identifiers (e.g., ` ```python ... ``` `). This enhances the clarity and readability of code snippets in the chat.
 - **Context Management**:


### PR DESCRIPTION
This feature allows you to save, load, and delete multiple chat sessions, enhancing usability for managing different conversations or projects.

Modifications:
- `app.py`:
    - Introduced a new local storage structure (`deepseek_code_companion_sessions_v2`) to store multiple named chat sessions. Each session includes its message log.
    - Added UI elements to the sidebar for session management:
        - Text input to name and save the current session.
        - Button to trigger saving the current session. - Selectbox to list and load saved sessions. - Selectbox to list and delete saved sessions, with a confirmation button.
    - Implemented logic to handle: - Saving the current `message_log` to local storage under a name you provide. - Loading a selected session's `message_log` into the active chat view. - Deleting a selected session from local storage.
    - Updated the "Clear Chat History" button to reset the current chat to a new, unsaved state, without deleting any saved sessions.
    - The application now starts with a fresh, unnamed session.
    - Helper functions were added for interacting with the local storage data.

- `README.md`:
    - Added a new "Session Management" section under "Features and Usage".
    - This section details how to save, load, and delete sessions, and clarifies the behavior of the "Clear Chat History" button.
    - Removed outdated information about the previous single-session chat history persistence.

This provides you with greater control over your chat histories and allows you to easily switch between different contexts.