### PR TITLE
feat: Implement streaming for LLM responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Once the app is running, interact with the AI Assistant via the web interface:
         - The application UI should not freeze during LLM processing.
         - The app uses `streamlit-autorefresh` to periodically check for results in the background, which may cause slight, brief screen refreshes while waiting for the AI's response.
     - This is achieved using a background task manager (`LLMTaskManager`) and the `streamlit-autorefresh` component for periodic updates.
+- **Streaming Responses**: AI responses now stream in token by token. This means you'll start seeing the beginning of longer responses much faster, significantly improving the perceived responsiveness of the assistant.
 
 ### Example Queries:
 

--- a/task_manager.py
+++ b/task_manager.py
@@ -14,16 +14,78 @@ class LLMTaskManager:
             st.session_state._llm_tasks_futures = {}
         if '_llm_tasks_results' not in st.session_state:
             st.session_state._llm_tasks_results = {}
+        # For storing full streamed content if needed, though primary is via session_state["task_{task_id}_stream_content"]
+        if '_llm_tasks_full_streamed_results' not in st.session_state:
+            st.session_state._llm_tasks_full_streamed_results = {}
+
+
+    def _process_streaming_task(self, task_id, target_func, args_tuple, kwargs_dict):
+        """
+        Internal method to execute the target function (which is a generator)
+        and handle its streaming output or errors.
+        Updates st.session_state for live streaming and stores final result/error.
+        """
+        st.session_state[f"task_{task_id}_stream_content"] = ""
+        st.session_state[f"task_{task_id}_stream_status"] = "streaming"
+        # Optional: st.session_state[f"task_{task_id}_stream_error_details"] = None
+
+        accumulated_content_for_final_result = []
+        target_func_name = target_func.__name__ # For logging
+
+        try:
+            generator = target_func(*args_tuple, **kwargs_dict)
+            first_chunk = True
+
+            for chunk in generator:
+                if first_chunk:
+                    # Check for prefixed error message from llm_logic.py
+                    if isinstance(chunk, str) and (chunk.startswith("OLLAMA_CONNECTION_ERROR:") or \
+                       chunk.startswith("LLM_RUNTIME_ERROR:") or \
+                       chunk.startswith("LLM_UNEXPECTED_ERROR:")):
+                        logging.error(f"Task {task_id} ({target_func_name}) yielded a prefixed error: {chunk}")
+                        st.session_state[f"task_{task_id}_stream_status"] = "error"
+                        # st.session_state[f"task_{task_id}_stream_error_details"] = chunk
+                        # Store the error string itself as an Exception for get_task_result compatibility
+                        return Exception(chunk) # This becomes the result of the future
+                    first_chunk = False
+
+                # Append chunk to session state for app.py to display
+                # Ensure chunk is a string before concatenation
+                chunk_str = chunk if isinstance(chunk, str) else str(chunk)
+                st.session_state[f"task_{task_id}_stream_content"] += chunk_str
+                accumulated_content_for_final_result.append(chunk_str)
+
+            # Stream completed successfully
+            final_result_str = "".join(accumulated_content_for_final_result)
+            st.session_state[f"task_{task_id}_stream_status"] = "completed"
+            # Store the full result for get_task_result
+            # st.session_state._llm_tasks_full_streamed_results[task_id] = final_result_str
+            return final_result_str # This becomes the result of the future
+
+        except Exception as e:
+            # Handle exceptions that occur if target_func itself fails before/during iteration
+            logging.exception(f"Exception during task {task_id} ({target_func_name}) execution: {e}")
+            st.session_state[f"task_{task_id}_stream_status"] = "error"
+            # st.session_state[f"task_{task_id}_stream_error_details"] = str(e)
+            return e # This exception instance becomes the result of the future
+
 
     def submit_task(self, func, *args, **kwargs):
         """
         Submits a function to the executor and returns a unique task ID.
-        Stores the future in st.session_state._llm_tasks_futures.
+        If the function is a generator (for streaming), it's wrapped by _process_streaming_task.
         """
         task_id = str(uuid.uuid4())
-        future = self._executor.submit(func, *args, **kwargs)
+
+        # Initialize stream-related session state immediately on submission
+        st.session_state[f"task_{task_id}_stream_content"] = ""
+        st.session_state[f"task_{task_id}_stream_status"] = "submitted" # Initial status
+
+        # The actual function submitted to the executor is now _process_streaming_task,
+        # which will call the original 'func' (generate_ai_response).
+        future = self._executor.submit(self._process_streaming_task, task_id, func, args, kwargs)
         st.session_state._llm_tasks_futures[task_id] = future
-        logging.info(f"Task {task_id} submitted for function {func.__name__}")
+        logging.info(f"Task {task_id} submitted for function {func.__name__} (wrapped by _process_streaming_task).")
         return task_id
 
     def get_task_status(self, task_id):
@@ -33,40 +95,76 @@ class LLMTaskManager:
         and removes future from st.session_state._llm_tasks_futures.
         """
         if task_id not in st.session_state._llm_tasks_futures:
-            # Check if it was completed and future removed, but result is available
+            # Check if result is already stored (task finished and future removed)
             if task_id in st.session_state._llm_tasks_results:
-                 # If result is an Exception, it's an error status
                 return "error" if isinstance(st.session_state._llm_tasks_results[task_id], Exception) else "completed"
+            # Or if stream status indicates completion/error, but future might be gone due to quick completion
+            stream_status = st.session_state.get(f"task_{task_id}_stream_status")
+            if stream_status == "completed": return "completed"
+            if stream_status == "error": return "error"
             return "not_found"
 
         future = st.session_state._llm_tasks_futures[task_id]
 
         if future.running():
+            # For streaming tasks, "running" means the _process_streaming_task is running.
+            # The actual stream progress is in st.session_state[f"task_{task_id}_stream_status"]
+            # ("submitted", "streaming", "completed", "error")
+            # This method can return "running" and app.py can check the stream_status for finer details.
             return "running"
         elif future.done():
+            # _process_streaming_task has finished. Its return value (or exception) is the "result".
             try:
-                result = future.result()
-                st.session_state._llm_tasks_results[task_id] = result
-                logging.info(f"Task {task_id} completed. Result stored.")
-                del st.session_state._llm_tasks_futures[task_id] # Clean up future
-                return "completed"
-            except Exception as e:
-                st.session_state._llm_tasks_results[task_id] = e # Store exception as result
-                logging.error(f"Task {task_id} resulted in error: {e}")
-                del st.session_state._llm_tasks_futures[task_id] # Clean up future
+                result_or_exception = future.result() # This is what _process_streaming_task returned
+                st.session_state._llm_tasks_results[task_id] = result_or_exception
+
+                # Update stream_status one last time based on future's result if not already set by _process_streaming_task
+                # This handles cases where _process_streaming_task itself might fail before setting stream_status.
+                current_stream_status = st.session_state.get(f"task_{task_id}_stream_status", "unknown")
+                if isinstance(result_or_exception, Exception):
+                    if current_stream_status != "error": # Don't overwrite if already set by _process_streaming_task
+                        st.session_state[f"task_{task_id}_stream_status"] = "error"
+                    logging.error(f"Task {task_id} (wrapper) resulted in error: {result_or_exception}")
+                    del st.session_state._llm_tasks_futures[task_id]
+                    return "error"
+                else: # Successfully completed
+                    if current_stream_status not in ["completed", "error"]: # Avoid overwriting specific error from inside stream
+                         st.session_state[f"task_{task_id}_stream_status"] = "completed"
+                    logging.info(f"Task {task_id} (wrapper) completed. Final result stored.")
+                    del st.session_state._llm_tasks_futures[task_id]
+                    return "completed"
+
+            except Exception as e: # Should ideally be caught by the future.result() line above
+                st.session_state._llm_tasks_results[task_id] = e
+                st.session_state[f"task_{task_id}_stream_status"] = "error" # Ensure status reflects this
+                logging.error(f"Task {task_id} (wrapper) future.result() raised an unexpected exception: {e}")
+                if task_id in st.session_state._llm_tasks_futures: # Ensure cleanup
+                    del st.session_state._llm_tasks_futures[task_id]
                 return "error"
-        return "unknown" # Should ideally not happen
+
+        # Fallback based on stream status if future is somehow not running or done but still present
+        # This also helps if called before future.done() is true but stream is already working
+        return st.session_state.get(f"task_{task_id}_stream_status", "unknown")
+
 
     def get_task_result(self, task_id):
         """
-        Returns the result of a completed task from st.session_state._llm_tasks_results.
-        Returns None if task is not found or result not yet available (should check status first).
+        Returns the final result of a completed task (e.g., full accumulated string for streams).
         Raises the exception if the task resulted in an error.
         """
-        result = st.session_state._llm_tasks_results.get(task_id)
-        if isinstance(result, Exception):
-            raise result # Re-raise the exception so caller can handle
-        return result
+        # Prioritize result from _llm_tasks_results as it's set when future completes
+        if task_id in st.session_state._llm_tasks_results:
+            result = st.session_state._llm_tasks_results[task_id]
+            if isinstance(result, Exception):
+                raise result
+            return result
+
+        # Fallback for tasks that might have completed streaming but future not yet processed by get_task_status
+        # This is less likely with the current structure but provides a fallback.
+        # if st.session_state.get(f"task_{task_id}_stream_status") == "completed":
+        #     return st.session_state.get(f"task_{task_id}_stream_content", "") # Or from _llm_tasks_full_streamed_results
+
+        return None # Task not found or not yet completed
 
     def cleanup_task_result(self, task_id):
         """
@@ -74,10 +172,14 @@ class LLMTaskManager:
         """
         if task_id in st.session_state._llm_tasks_results:
             del st.session_state._llm_tasks_results[task_id]
-            logging.info(f"Cleaned up result for task {task_id}")
+        # Clean up stream-specific states as well
+        if f"task_{task_id}_stream_content" in st.session_state:
+            del st.session_state[f"task_{task_id}_stream_content"]
+        if f"task_{task_id}_stream_status" in st.session_state:
+            del st.session_state[f"task_{task_id}_stream_status"]
+        # if f"task_{task_id}_stream_error_details" in st.session_state:
+        #     del st.session_state[f"task_{task_id}_stream_error_details"]
+        # if task_id in st.session_state._llm_tasks_full_streamed_results: # If used
+        #     del st.session_state._llm_tasks_full_streamed_results[task_id]
 
-
-# To ensure the singleton is initialized when the module is imported.
-# This allows app.py to just import and use it.
-# get_llm_task_manager = LLMTaskManager() # This is not how singletons are typically "pre-initialized" for use.
-# Instead, the app will call LLMTaskManager() and st.experimental_singleton handles it.
+        logging.info(f"Cleaned up result and stream states for task {task_id}")


### PR DESCRIPTION
This feature enhances your experience by displaying responses from me in a streaming fashion (token by token), rather than waiting for the entire response to be generated. This significantly improves perceived performance.

Modifications:
- `llm_logic.py`:
    - The `generate_ai_response` function was converted into a generator. It now uses the `.stream()` method of the LangChain pipeline and `yields` response chunks as they are received from the LLM.
    - Error handling within `generate_ai_response` was adapted to `yield` prefixed error messages if an error occurs during stream setup.

- `task_manager.py`:
    - Refactored `LLMTaskManager` to support generator-based target functions.
    - A new `_process_streaming_task` method now handles the execution of the streaming `generate_ai_response`. This method iterates over the response chunks.
    - For each task, it updates `st.session_state` with:
        - `task_{task_id}_stream_content`: The accumulated content received so far.
        - `task_{task_id}_stream_status`: The current status ("streaming", "completed", "error").
    - The final accumulated result or any exception (including prefixed errors from `llm_logic.py` wrapped as exceptions) is stored for the traditional `get_task_result` method.
    - Methods like `submit_task`, `get_task_status`, and `cleanup_task_result` were updated to integrate with this new streaming process and manage the relevant session state keys.

- `app.py`:
    - The main result checking loop (driven by `st_autorefresh`) was updated to poll `st.session_state` for `task_{task_id}_stream_status` and `task_{task_id}_stream_content`.
    - When `stream_status` is "streaming", my message placeholder in the chat UI is continuously updated with the `stream_content`, rendering the response token by token.
    - When `stream_status` is "completed" or "error", the application finalizes the message, updates UI state (e.g., re-enables chat input), and cleans up the task. Error handling uses the established prominent error display.

- `README.md`:
    - Added a "- Streaming Responses" bullet point in the "Features and Usage" section to inform you of this enhancement.

This change provides a much more interactive and responsive feel when waiting for longer outputs from me.