### PR TITLE
feat: Add export chat history functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Once the app is running, interact with the AI Assistant via the web interface:
     - **Loading Sessions**: To resume a previous conversation, select its name from the "Load Session:" dropdown in the sidebar. The chat history will be loaded, and the session name will be displayed.
     - **Deleting Sessions**: To remove a saved session, select its name from the "Delete Session:" dropdown and click "Delete Selected Session". This will permanently remove it from your browser's local storage.
     - **Starting a New Session**: Click the "Clear Chat History" button in the sidebar. This will clear the current chat display and start a fresh, unnamed session. It does not delete any of your saved sessions.
+    - **Exporting Chat History**: You can download the currently active chat conversation as a Markdown file. Click the "📥 Download Chat History" button located within the "💾 Chat Sessions" section in the sidebar. The downloaded file will be named using the current session name (if saved/named) or "Chat" along with a timestamp, ensuring a unique filename (e.g., `MySessionName_20231027_143000.md`).
     - All session data is stored locally in your web browser.
 - **Improved Error Notifications**: Critical errors, such as issues connecting to the AI model, are now displayed prominently at the top of the chat interface with troubleshooting tips. File processing errors will appear in the sidebar. This provides clearer feedback on any operational issues.
 - **Improved Code Formatting**:


### PR DESCRIPTION
This feature allows you to download the current chat conversation as a Markdown file.

Modifications:
- `app.py`:
    - I imported `datetime` for timestamp generation.
    - I implemented a new helper function `format_chat_history_for_markdown(message_log, session_name)` that:
        - Takes the current message log and session name as input.
        - Formats the entire chat history into a single Markdown string. - Includes a title with the session name (or a generic title with a timestamp for unsaved sessions). - Clearly indicates user and AI roles for each message. - Uses Markdown horizontal rules as separators between messages. - Preserves the original Markdown formatting of my responses, including code blocks.
    - I added an `st.download_button` to the sidebar under the "Chat Sessions" section, labeled "📥 Download Chat History". - This button uses the `format_chat_history_for_markdown` function to generate the file content. - The downloaded file is given a dynamic name incorporating the session name (if available) and a timestamp (e.g., `SessionName_YYYYMMDD_HHMMSS.md` or `Chat_YYYYMMDD_HHMMSS.md`), with unsafe characters replaced. - The MIME type for the download is set to "text/markdown". - The button is only displayed if there is a chat history.

- `README.md`:
    - I updated the "Session Management" subsection within "Features and Usage" to include details about the new "Exporting Chat History" capability.

This enhancement provides you with a convenient way to save and share your chat conversations outside of the application.