### PR TITLE
feat: Implement feedback mechanism for AI responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Once the app is running, interact with the AI Assistant via the web interface:
         - The app uses `streamlit-autorefresh` to periodically check for results in the background, which may cause slight, brief screen refreshes while waiting for the AI's response.
     - This is achieved using a background task manager (`LLMTaskManager`) and the `streamlit-autorefresh` component for periodic updates.
 - **Streaming Responses**: AI responses now stream in token by token. This means you'll start seeing the beginning of longer responses much faster, significantly improving the perceived responsiveness of the assistant.
+- **Feedback on AI Responses**: You can provide feedback on individual AI messages using the "👍" (helpful) and "👎" (not helpful) buttons located beneath each AI response. Once feedback is given for a message, the buttons for that message will be disabled. This feedback is stored as part of your chat session if you save the session. (Note: Currently, this feedback is only stored locally and not sent to any central server for analysis.)
 
 ### Example Queries:
 


### PR DESCRIPTION
This feature adds thumbs-up (👍) and thumbs-down (👎) buttons to each AI-generated message, allowing you to provide feedback on the quality or helpfulness of the responses.

Modifications:
- `app.py`:
    - In `display_chat_interface`: - Added "👍" and "👎" buttons beneath each AI message. - Buttons are assigned unique keys based on their message index. - Once feedback is provided for a message, the buttons for that message become disabled.
    - Implemented click handling logic for these feedback buttons within `display_chat_interface`:
        - When a feedback button is clicked, a 'feedback' field (e.g., 'thumbs_up' or 'thumbs_down') is added/updated in the corresponding message dictionary within `st.session_state.message_log`.
        - Feedback activity (type of feedback and message index/snippet) is logged to the console for developer visibility. - If the current chat session is a named (saved) session, the entire `st.session_state.message_log` (now including the new feedback) is saved back to local storage, making the feedback persistent with that session. - `st.rerun()` is called after feedback is processed to ensure the UI (e.g., disabled buttons) updates immediately.

- `README.md`:
    - Added a new "- Feedback on AI Responses" bullet point in the "Features and Usage" section.
    - This documentation explains how to use the feedback buttons, notes that feedback is stored with saved sessions, and clarifies that the feedback is currently local and not sent to a central server.

This enhancement provides a way for you to indicate the utility of AI responses, with the feedback being preserved within their saved chat sessions.