### PR TITLE
chore: Refine project config files and add .gitignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,39 +2,85 @@
 .git
 .gitignore
 
+# Docker files themselves (usually not needed in the image build context)
+Dockerfile
+docker-compose.yml
+*.md # READMEs, etc., are often not needed in the final image unless used by app
+
 # Python virtual environment
 venv/
 *.venv/
 .venv/
+env/
+ENV/
+__pypackages__/
 
 # Python bytecode and cache
 __pycache__/
 *.py[cod]
 *$py.class
+.pytest_cache/
+
+# Distribution / packaging
+build/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
 
 # OS-specific files
 .DS_Store
 Thumbs.db
 
-# IDE and project files (examples, add more if needed for specific IDEs)
+# IDE and project files
 .idea/
 .vscode/
-*.suo
-*.ntvs*
-*.njsproj
-*.sln
-*.sw?
+*.project
+*.pydevproject
+*.記憶
+*.sublime-workspace
 
-# Secrets or local configuration (if any, though ideally not in repo)
-# .env
+# Secrets or local configuration
+.env
+*.env
 
-# Test reports or build artifacts (if any)
-# htmlcov/
-# .tox/
-# .nox/
-# .coverage
-# .cache
-# nosetests.xml
-# coverage.xml
-# *.cover
-# *.log
+# Miscellaneous
+*.log
+*.bak
+*.swp
+*~
+# .history
+
+# Streamlit secrets (if managed outside Docker secrets)
+# .streamlit/secrets.toml
+# Note: If .streamlit/secrets.toml is essential AND part of the repo (not recommended for real secrets),
+# then do NOT add it here. Typically, secrets are mounted or injected, not copied.
+# For this project, it seems secrets are not used this way.

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,134 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+# Usually these files are written by a CI script in a temporary folder in the
+# build directory, so adding them here is kind of redundant.
+# *.manifest
+# *.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+# .python-version
+
+# PEP 582; __pypackages__ directory
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Streamlit secrets
+.streamlit/secrets.toml
+
+# System files
+.DS_Store
+Thumbs.db
+
+# IDEs and editors
+/.idea/
+/.vscode/
+*.project
+*.pydevproject
+*.記憶
+*.sublime-workspace
+
+# Cloud
+.terraform/
+terraform.tfstate
+terraform.tfstate.backup
+.serverless/
+serverless.yml
+serverless.yaml
+serverless.json
+.aws-sam/
+
+# Miscellaneous
+*.bak
+*.swp
+*~
+# .history # for VS Code local history

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - deepseek_net
 
   ollama:
-    image: ollama/ollama:latest # Use the latest official image
+    image: ollama/ollama:latest # Consider pinning to a specific version for more stable deployments, e.g., ollama/ollama:0.1.42
     ports:
       - "11434:11434"
     volumes:


### PR DESCRIPTION
This commit introduces a .gitignore file and refines .dockerignore and docker-compose.yml for improved development workflow and best practices.

Modifications:
- I created a new `.gitignore` file:
    - I populated it with a comprehensive set of standard ignore patterns for Python projects, including virtual environments, bytecode, OS-specific files, IDE configurations, and common temporary/log/distribution files. This will help you prevent unnecessary files from being tracked by Git.

- I refined the `.dockerignore` file:
    - I updated it with a more comprehensive list of patterns to exclude from the Docker build context. This includes patterns from the new .gitignore where relevant, as well as Docker-specific files like Dockerfile, docker-compose.yml, and *.md files, to help you minimize build context size.

- `docker-compose.yml`:
    - I added an informational comment next to `image: ollama/ollama:latest` recommending to pin the image to a specific version for more stable and reproducible deployments.

These changes improve your project's configuration for both local development and Docker builds.